### PR TITLE
Add saving model functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ target/
 # Added by cargo
 
 /target
+
+# Program specific
+trained_svm_model.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "approx"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +280,26 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
 
 [[package]]
 name = "bitflags"
@@ -952,6 +978,7 @@ dependencies = [
  "linfa-nn",
  "ndarray",
  "num-traits",
+ "serde",
  "sprs",
 ]
 
@@ -982,6 +1009,7 @@ dependencies = [
  "ndarray",
  "ndarray-rand",
  "num-traits",
+ "serde",
  "thiserror",
 ]
 
@@ -1079,6 +1107,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rawpointer",
+ "serde",
 ]
 
 [[package]]
@@ -1528,6 +1557,7 @@ dependencies = [
  "ndarray",
  "num-complex",
  "num-traits",
+ "serde",
  "smallvec",
 ]
 
@@ -1548,6 +1578,8 @@ name = "svm"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "anyhow",
+ "bincode",
  "chrono",
  "env_logger",
  "glob",
@@ -1757,6 +1789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,6 +1832,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,10 @@ log = "0.4.17"
 env_logger = "0.10.0"
 uuid = { version = "1.3.3", features = ["v4", "serde"] }
 linfa = "0.7.1"
-linfa-svm = "0.7.2"
+linfa-svm = { version = "0.7.2", default-features = false, features = ["serde"] }
 rustfft = "6.3.0"
 glob = "0.3.2"
 ndarray = "0.15.6"
 tokio = { version = "1", features = ["full"] }
+anyhow = "1.0.98"
+bincode = { version = "2.0.1", features = ["std"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -355,7 +355,6 @@ async fn main() -> std::io::Result<()> {
         model: RwLock::new(None),
     });
 
-    // Configurar tamaño máximo de payload (10 MB)
     let json_config = web::JsonConfig::default()
         .limit(1 << 26)  // Tamaño max de 2^26 bytes (64 MB)
         .error_handler(|err, _req| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,7 +393,7 @@ async fn main() -> std::io::Result<()> {
     // Try to load model
     let model_loaded = app_state.load_model_json(MODEL_PATH);
     match model_loaded {
-        Ok(_) => log::info!("Model loaded from {MODEL_PATH}"),
+        Ok(_) => log::info!("Model loaded from {}", MODEL_PATH),
         Err(_) => log::info!("Model could not be loaded"),
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,9 +18,34 @@ use crate::signals::SignalType;
 
 // Startup time for uptime calculation
 static mut START_TIME: Option<Instant> = None;
+const MODEL_PATH: &str = "trained_svm_model.json";
 
 struct AppState {
     model: RwLock<Option<Svm<f64, bool>>>,
+}
+
+impl AppState {
+    fn save_model_json(&self, path: &str) -> anyhow::Result<()> {
+        let model = self.model.read().unwrap();
+        if let Some(model) = &*model {
+            let json = serde_json::to_string(model)?;
+            std::fs::write(path, json).map_err(|e| anyhow::anyhow!("Failed to save model: {}", e))?;
+        } else {
+            return Err(anyhow::anyhow!("No model to save"));
+        }
+
+        log::info!("Model saved successfully to {}", path);
+
+        Ok(())
+    }
+
+    fn load_model_json(&self, path: &str) -> anyhow::Result<()> {
+        let model_data = std::fs::read_to_string(path)?;
+        let model: Svm<f64, bool> = serde_json::from_str(&model_data)?;
+        *self.model.write().unwrap() = Some(model);
+        log::info!("Model loaded successfully from {}", path);
+        Ok(())
+    }    
 }
 
 // Data structures based on API schema
@@ -304,8 +329,18 @@ async fn train(req: web::Json<TrainingRequest>, app_state: web::Data<AppState>) 
     println!("Received training petition");
     let (response, model) = process_training_request(&req);
 
-    let mut model_lock = app_state.model.write().unwrap();
-    *model_lock = Some(model);
+    {
+        let mut model_lock: std::sync::RwLockWriteGuard<'_, Option<Svm<f64, bool>>> = app_state.model.write().unwrap();
+        *model_lock = Some(model);
+    } // When model_lock goes out of scope, the lock is released
+
+    // Save the trained model to a file
+    let model_path = MODEL_PATH;
+    let res = app_state.save_model_json(model_path);
+    
+    if res.is_err() {
+        log::warn!("Unable to save model")
+    }
 
     HttpResponse::Ok().json(response)
 }
@@ -354,6 +389,13 @@ async fn main() -> std::io::Result<()> {
     let app_state = web::Data::new(AppState {
         model: RwLock::new(None),
     });
+
+    // Try to load model
+    let model_loaded = app_state.load_model_json(MODEL_PATH);
+    match model_loaded {
+        Ok(_) => log::info!("Model loaded from {MODEL_PATH}"),
+        Err(_) => log::info!("Model could not be loaded"),
+    }
 
     let json_config = web::JsonConfig::default()
         .limit(1 << 26)  // Tamaño max de 2^26 bytes (64 MB)


### PR DESCRIPTION
This pull request introduces changes to enhance model persistence by adding functionality to save and load the trained SVM model in JSON format. It also includes dependency updates and minor refactoring to improve code clarity and maintainability.

### Model Persistence Enhancements:
* Added `save_model_json` and `load_model_json` methods to the `AppState` struct for saving and loading the trained SVM model in JSON format using `serde_json`. These methods provide error handling and log messages for success or failure. (`src/main.rs`, [src/main.rsR21-R50](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR21-R50))
* Updated the `train` function to save the trained model to a file (`trained_svm_model.json`) after training is completed. Added error handling and logging for the save operation. (`src/main.rs`, [src/main.rsL307-R343](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL307-R343))
* Modified the `main` function to attempt loading the model from the file (`trained_svm_model.json`) at startup, with appropriate logging to indicate success or failure. (`src/main.rs`, [src/main.rsL358-R399](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL358-R399))

### Dependency Updates:
* Updated the `linfa-svm` dependency to disable default features and enable the `serde` feature for serialization support. Added new dependencies: `anyhow` for error handling and `bincode` for potential binary serialization needs. (`Cargo.toml`, [Cargo.tomlL15-R21](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R21))

Closes #3
