### PR TITLE
Implement outlier protocol endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -29,8 +29,8 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "base64",
- "bitflags",
+ "base64 0.22.1",
+ "bitflags 2.9.0",
  "brotli",
  "bytes",
  "bytestring",
@@ -272,8 +272,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -300,6 +306,12 @@ checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
 dependencies = [
  "virtue",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -399,6 +411,16 @@ dependencies = [
  "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -521,6 +543,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "flate2"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,12 +581,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -675,6 +737,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +764,43 @@ name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -882,6 +992,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1130,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1215,23 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1195,6 +1334,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "order-stat"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,7 +1403,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1376,7 +1559,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -1415,6 +1598,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1659,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,10 +1693,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -1587,6 +1864,7 @@ dependencies = [
  "linfa-svm",
  "log",
  "ndarray",
+ "reqwest",
  "rustfft",
  "serde",
  "serde_json",
@@ -1606,6 +1884,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,6 +1898,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1716,6 +2034,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,6 +2055,12 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1769,6 +2103,12 @@ dependencies = [
  "num-integer",
  "strength_reduce",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -1828,6 +2168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,6 +2184,15 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1881,6 +2236,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,6 +2278,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1982,11 +2360,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1995,7 +2382,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2004,15 +2406,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2022,9 +2430,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2040,9 +2460,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2052,9 +2484,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2063,12 +2507,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ ndarray = "0.15.6"
 tokio = { version = "1", features = ["full"] }
 anyhow = "1.0.98"
 bincode = { version = "2.0.1", features = ["std"] }
+reqwest = { version = "0.11", features = ["json"] }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # svm
-SVM classifier
+SVM classifier implementing the node outlier protocol.
+
+### Endpoints
+
+- `GET /health` – returns model name, uptime and last training timestamp.
+- `POST /predict` – submit a discharge and obtain a disruption prediction.
+- `POST /train` – begin a new training session specifying the number of
+  discharges that will be uploaded.
+- `POST /train/{ordinal}` – push each discharge sequentially. When the last
+  discharge is received the model is trained automatically.

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,15 @@ use crate::signals::SignalType;
 static mut START_TIME: Option<Instant> = None;
 const MODEL_PATH: &str = "trained_svm_model.json";
 
+struct TrainingSession {
+    total_discharges: usize,
+    discharges: Vec<Discharge>,
+}
+
 struct AppState {
     model: RwLock<Option<Svm<f64, bool>>>,
+    training: RwLock<Option<TrainingSession>>,
+    last_training: RwLock<Option<DateTime<Utc>>>,
 }
 
 impl AppState {
@@ -45,65 +52,65 @@ impl AppState {
         *self.model.write().unwrap() = Some(model);
         log::info!("Model loaded successfully from {}", path);
         Ok(())
-    }    
+    }
 }
 
 // Data structures based on API schema
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 struct Signal {
-    #[serde(rename = "fileName")]
-    file_name: String,
+    #[serde(rename = "filename")]
+    filename: String,
     values: Vec<f64>,
-    #[serde(default)]
-    _times: Vec<f64>,
-    #[serde(default)]
-    _length: usize,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 struct Discharge {
+    #[allow(dead_code)]
     id: String,
-    #[serde(default)]
-    _times: Vec<f64>,
-    #[serde(default)]
-    _length: usize,
+    #[allow(dead_code)]
+    times: Vec<f64>,
+    #[allow(dead_code)]
+    length: usize,
     #[serde(default, rename = "anomalyTime")]
     anomaly_time: Option<f64>,
     signals: Vec<Signal>,
 }
 
 #[derive(Deserialize)]
-struct PredictionRequest {
-    discharges: Vec<Discharge>,
+struct StartTrainingRequest {
+    #[serde(rename = "totalDischarges")]
+    total_discharges: usize,
+    #[serde(rename = "timeoutSeconds")]
+    #[allow(dead_code)]
+    timeout_seconds: usize,
 }
 
 #[derive(Serialize)]
+struct StartTrainingResponse {
+    #[serde(rename = "expectedDischarges")]
+    expected_discharges: usize,
+}
+
+#[derive(Serialize)]
+struct DischargeAck {
+    ordinal: usize,
+    #[serde(rename = "totalDischarges")]
+    total_discharges: usize,
+}
+
+
+#[derive(Serialize)]
 struct PredictionResponse {
-    prediction: i32,
+    prediction: String,
     confidence: f64,
     #[serde(rename = "executionTimeMs")]
     execution_time_ms: f64,
     model: String,
-    details: serde_json::Value,
 }
 
 #[derive(Deserialize)]
-struct TrainingOptions {
-    #[serde(default)]
-    _epochs: Option<i32>,
-    #[serde(default, rename = "batchSize")]
-    _batch_size: Option<i32>,
-    #[serde(default)]
-    _hyperparameters: Option<serde_json::Value>,
-}
 
-#[derive(Deserialize)]
-struct TrainingRequest {
-    discharges: Vec<Discharge>,
-    #[serde(default)]
-    _options: Option<TrainingOptions>,
-}
 
 #[derive(Serialize)]
 struct TrainingMetrics {
@@ -125,18 +132,9 @@ struct TrainingResponse {
 }
 
 #[derive(Serialize)]
-struct MemoryInfo {
-    total: f64,
-    used: f64,
-}
-
-#[derive(Serialize)]
 struct HealthCheckResponse {
-    status: String,
-    version: String,
+    name: String,
     uptime: f64,
-    memory: MemoryInfo,
-    load: f64,
     #[serde(rename = "lastTraining")]
     last_training: String,
 }
@@ -178,9 +176,9 @@ fn api_signal_to_internal(
     signal_class: DisruptionClass,
 ) -> Result<InternalSignal, String> {
     // Obtener el tipo de señal a partir del nombre del archivo
-    let signal_type = get_discharge_type_from_file_name(&api_signal.file_name)?;
+    let signal_type = get_discharge_type_from_file_name(&api_signal.filename)?;
     Ok(InternalSignal::new(
-        api_signal.file_name.clone(),
+        api_signal.filename.clone(),
         api_signal.values.clone(),
         signal_class,
         signal_type,
@@ -209,7 +207,7 @@ fn api_discharge_to_internal_signals(discharge: &Discharge) -> Vec<InternalSigna
 
 /// Procesa una petición de predicción
 fn process_prediction_request(
-    request: &PredictionRequest,
+    discharge: &Discharge,
     model: &Option<Svm<f64, bool>>,
 ) -> PredictionResponse {
     let start_time = Instant::now();
@@ -217,20 +215,17 @@ fn process_prediction_request(
     // Si no hay modelo entrenado, devolver respuesta por defecto
     if model.is_none() {
         return PredictionResponse {
-            prediction: -1,
+            prediction: "Unknown".to_string(),
             confidence: 0.0,
             execution_time_ms: 0.0,
             model: "none".to_string(),
-            details: serde_json::json!({ "error": "No hay modelo entrenado" }),
         };
     }
 
-    let discharges = request.discharges.iter().map(|d| {
-        InternalDischarge::new(
-            DisruptionClass::Unknown, // La clase es desconocida en predicción
-            api_discharge_to_internal_signals(d),
-        )
-    }).collect::<Vec<_>>();
+    let discharges = vec![InternalDischarge::new(
+        DisruptionClass::Unknown,
+        api_discharge_to_internal_signals(discharge),
+    )];
     
     let dataset = get_dataset(discharges);
     
@@ -243,26 +238,22 @@ fn process_prediction_request(
     let total = predictions.len();
     let confidence = if total > 0 { anomaly_count as f64 / total as f64 } else { 0.0 };
     
-    let prediction = if confidence > 0.5 { 1 } else { 0 };
+    let prediction = if confidence > 0.5 { "Anomaly" } else { "Normal" };
     
     PredictionResponse {
-        prediction,
+        prediction: prediction.to_string(),
         confidence,
         execution_time_ms: start_time.elapsed().as_millis() as f64,
         model: "svm".to_string(),
-        details: serde_json::json!({
-            "anomalyRatio": confidence
-        }),
     }
 }
 
 /// Procesa una petición de entrenamiento
-fn process_training_request(request: &TrainingRequest) -> (TrainingResponse, Svm<f64, bool>) {
+fn process_training_request(discharges: &[Discharge]) -> (TrainingResponse, Svm<f64, bool>) {
     // Convertir todas las descargas y señales al formato interno
     let start_time = Instant::now();
 
-    let discharges = request
-        .discharges
+    let discharges = discharges
         .iter()
         .map(|d| {
             InternalDischarge::new(
@@ -316,7 +307,7 @@ fn process_training_request(request: &TrainingRequest) -> (TrainingResponse, Svm
 
 #[post("/predict")]
 async fn predict(
-    req: web::Json<PredictionRequest>,
+    req: web::Json<Discharge>,
     app_state: web::Data<AppState>,
 ) -> impl Responder {
     let model = app_state.model.read().unwrap();
@@ -325,28 +316,49 @@ async fn predict(
 }
 
 #[post("/train")]
-async fn train(req: web::Json<TrainingRequest>, app_state: web::Data<AppState>) -> impl Responder {
-    println!("Received training petition");
-    let (response, model) = process_training_request(&req);
-
-    {
-        let mut model_lock: std::sync::RwLockWriteGuard<'_, Option<Svm<f64, bool>>> = app_state.model.write().unwrap();
-        *model_lock = Some(model);
-    } // When model_lock goes out of scope, the lock is released
-
-    // Save the trained model to a file
-    let model_path = MODEL_PATH;
-    let res = app_state.save_model_json(model_path);
-    
-    if res.is_err() {
-        log::warn!("Unable to save model")
+async fn start_training(req: web::Json<StartTrainingRequest>, app_state: web::Data<AppState>) -> impl Responder {
+    let mut training_lock = app_state.training.write().unwrap();
+    if training_lock.is_some() {
+        return HttpResponse::ServiceUnavailable().finish();
     }
+    let session = TrainingSession {
+        total_discharges: req.total_discharges,
+        discharges: Vec::with_capacity(req.total_discharges),
+    };
+    *training_lock = Some(session);
+    HttpResponse::Ok().json(StartTrainingResponse { expected_discharges: req.total_discharges })
+}
 
-    HttpResponse::Ok().json(response)
+#[post("/train/{ordinal}")]
+async fn push_discharge(path: web::Path<usize>, req: web::Json<Discharge>, app_state: web::Data<AppState>) -> impl Responder {
+    let ordinal = path.into_inner();
+    let mut training_lock = app_state.training.write().unwrap();
+    if let Some(session) = training_lock.as_mut() {
+        if ordinal != session.discharges.len() + 1 || ordinal > session.total_discharges {
+            return HttpResponse::BadRequest().finish();
+        }
+        session.discharges.push(req.into_inner());
+        let total = session.total_discharges;
+        if ordinal == total {
+            let discharges = training_lock.take().unwrap().discharges;
+            drop(training_lock);
+            let (_response, model) = process_training_request(&discharges);
+            {
+                let mut model_lock = app_state.model.write().unwrap();
+                *model_lock = Some(model);
+            }
+            let _ = app_state.save_model_json(MODEL_PATH);
+            *app_state.last_training.write().unwrap() = Some(Utc::now());
+            // TODO: send webhook with `response`
+            return HttpResponse::Ok().json(DischargeAck { ordinal, total_discharges: total });
+        }
+        return HttpResponse::Ok().json(DischargeAck { ordinal, total_discharges: total });
+    }
+    HttpResponse::ServiceUnavailable().finish()
 }
 
 #[get("/health")]
-async fn health_check() -> impl Responder {
+async fn health_check(app_state: web::Data<AppState>) -> impl Responder {
     // Calculate uptime in seconds
     let uptime = unsafe {
         if let Some(start_time) = START_TIME {
@@ -358,19 +370,17 @@ async fn health_check() -> impl Responder {
 
     println!("Received heartbeat at {uptime}");
 
-    // Current date-time in ISO format
-    let now: DateTime<Utc> = Utc::now();
+    let last_training = app_state
+        .last_training
+        .read()
+        .unwrap()
+        .map(|dt| dt.to_rfc3339())
+        .unwrap_or_else(|| "never".to_string());
 
     let response = HealthCheckResponse {
-        status: "online".to_string(),
-        version: "1.0.0".to_string(),
+        name: "svm".to_string(),
         uptime,
-        memory: MemoryInfo {
-            total: 1024.0,
-            used: 512.0,
-        },
-        load: 0.3,
-        last_training: now.to_rfc3339(),
+        last_training,
     };
 
     HttpResponse::Ok().json(response)
@@ -388,6 +398,8 @@ async fn main() -> std::io::Result<()> {
 
     let app_state = web::Data::new(AppState {
         model: RwLock::new(None),
+        training: RwLock::new(None),
+        last_training: RwLock::new(None),
     });
 
     // Try to load model
@@ -413,12 +425,15 @@ async fn main() -> std::io::Result<()> {
 
 
     // Start the health check server in a separate thread
-    std::thread::spawn(|| {
+    let health_data = app_state.clone();
+    std::thread::spawn(move || {
         // Use the system runtime for the health check server
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
-            HttpServer::new(|| {
-                App::new().service(health_check)
+            HttpServer::new(move || {
+                App::new()
+                    .app_data(health_data.clone())
+                    .service(health_check)
             })
             .workers(1) // Use only one worker for health checks
             .bind(("0.0.0.0", 3001))
@@ -435,7 +450,8 @@ async fn main() -> std::io::Result<()> {
             .app_data(app_state.clone())
             .app_data(json_config.clone())  // Aplicar configuración de tamaño JSON
             .service(predict)
-            .service(train)
+            .service(start_training)
+            .service(push_discharge)
     })
     .bind(("0.0.0.0", 8001))?
     .run()

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ mod signals;
 
 use actix_web::{App, HttpResponse, HttpServer, Responder, get, post, web};
 use chrono::{DateTime, Utc};
+use log::info;
+use log::warn;
 use serde::{Deserialize, Serialize};
 use signals::get_dataset;
 use std::sync::RwLock;
@@ -19,6 +21,7 @@ use crate::signals::SignalType;
 // Startup time for uptime calculation
 static mut START_TIME: Option<Instant> = None;
 const MODEL_PATH: &str = "trained_svm_model.json";
+const WEBHOOK_URL_TRAINING_COMPLETED: &str = "http://localhost:3000/trainingCompleted";
 
 struct TrainingSession {
     total_discharges: usize,
@@ -29,6 +32,7 @@ struct AppState {
     model: RwLock<Option<Svm<f64, bool>>>,
     training: RwLock<Option<TrainingSession>>,
     last_training: RwLock<Option<DateTime<Utc>>>,
+    http_client: reqwest::Client,
 }
 
 impl AppState {
@@ -36,7 +40,8 @@ impl AppState {
         let model = self.model.read().unwrap();
         if let Some(model) = &*model {
             let json = serde_json::to_string(model)?;
-            std::fs::write(path, json).map_err(|e| anyhow::anyhow!("Failed to save model: {}", e))?;
+            std::fs::write(path, json)
+                .map_err(|e| anyhow::anyhow!("Failed to save model: {}", e))?;
         } else {
             return Err(anyhow::anyhow!("No model to save"));
         }
@@ -52,6 +57,34 @@ impl AppState {
         *self.model.write().unwrap() = Some(model);
         log::info!("Model loaded successfully from {}", path);
         Ok(())
+    }
+
+    /// Send webhook notification about training completion
+    async fn send_training_webhook(&self, response: &TrainingResponse) {
+        log::info!(
+            "Sending training completion webhook to: {}",
+            WEBHOOK_URL_TRAINING_COMPLETED
+        );
+
+        match self
+            .http_client
+            .post(WEBHOOK_URL_TRAINING_COMPLETED)
+            .json(response)
+            .timeout(std::time::Duration::from_secs(30))
+            .send()
+            .await
+        {
+            Ok(resp) => {
+                if resp.status().is_success() {
+                    log::info!("Webhook sent successfully, status: {}", resp.status());
+                } else {
+                    log::warn!("Webhook failed with status: {}", resp.status());
+                }
+            }
+            Err(e) => {
+                log::error!("Failed to send webhook: {}", e);
+            }
+        }
     }
 }
 
@@ -99,7 +132,6 @@ struct DischargeAck {
     total_discharges: usize,
 }
 
-
 #[derive(Serialize)]
 struct PredictionResponse {
     prediction: String,
@@ -110,9 +142,7 @@ struct PredictionResponse {
 }
 
 #[derive(Deserialize)]
-
-
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 struct TrainingMetrics {
     accuracy: f64,
     loss: f64,
@@ -120,7 +150,7 @@ struct TrainingMetrics {
     f1_score: f64,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 struct TrainingResponse {
     status: String,
     message: String,
@@ -162,7 +192,7 @@ fn get_discharge_type_from_file_name(file_name: &str) -> Result<SignalType, Stri
         _ => return Err(format!("Unknown signal type: {}", signal_type_int)),
     };
 
-    println!(
+    log::debug!(
         "Detected file name: {} with signal type: {:?}",
         file_name, signal_type
     );
@@ -211,9 +241,14 @@ fn process_prediction_request(
     model: &Option<Svm<f64, bool>>,
 ) -> PredictionResponse {
     let start_time = Instant::now();
+    log::info!(
+        "Received prediction request for discharge ID: {}",
+        discharge.id
+    );
     
-    // Si no hay modelo entrenado, devolver respuesta por defecto
+    // If no model is loaded, return unknown prediction
     if model.is_none() {
+        log::warn!("No model loaded, returning unknown prediction");
         return PredictionResponse {
             prediction: "Unknown".to_string(),
             confidence: 0.0,
@@ -226,20 +261,27 @@ fn process_prediction_request(
         DisruptionClass::Unknown,
         api_discharge_to_internal_signals(discharge),
     )];
-    
+
     let dataset = get_dataset(discharges);
-    
+
     // Realizar predicción con el modelo
-    let predictions = model.as_ref().unwrap()
-        .predict(&dataset);
-    
+    let predictions = model.as_ref().unwrap().predict(&dataset);
+
     // Determinar si hay anomalía (true representa anomalía)
     let anomaly_count = predictions.iter().filter(|&&p| p).count();
     let total = predictions.len();
-    let confidence = if total > 0 { anomaly_count as f64 / total as f64 } else { 0.0 };
-    
-    let prediction = if confidence > 0.5 { "Anomaly" } else { "Normal" };
-    
+    let confidence = if total > 0 {
+        anomaly_count as f64 / total as f64
+    } else {
+        0.0
+    };
+
+    let prediction = if confidence > 0.5 {
+        "Anomaly"
+    } else {
+        "Normal"
+    };
+
     PredictionResponse {
         prediction: prediction.to_string(),
         confidence,
@@ -306,19 +348,24 @@ fn process_training_request(discharges: &[Discharge]) -> (TrainingResponse, Svm<
 // API endpoints
 
 #[post("/predict")]
-async fn predict(
-    req: web::Json<Discharge>,
-    app_state: web::Data<AppState>,
-) -> impl Responder {
+async fn predict(req: web::Json<Discharge>, app_state: web::Data<AppState>) -> impl Responder {
     let model = app_state.model.read().unwrap();
     let response = process_prediction_request(&req, &model);
     HttpResponse::Ok().json(response)
 }
 
 #[post("/train")]
-async fn start_training(req: web::Json<StartTrainingRequest>, app_state: web::Data<AppState>) -> impl Responder {
+async fn start_training(
+    req: web::Json<StartTrainingRequest>,
+    app_state: web::Data<AppState>,
+) -> impl Responder {
+    info!(
+        "Received training request for {} discharges",
+        req.total_discharges
+    );
     let mut training_lock = app_state.training.write().unwrap();
     if training_lock.is_some() {
+        warn!("Training session already in progress, rejecting new request");
         return HttpResponse::ServiceUnavailable().finish();
     }
     let session = TrainingSession {
@@ -326,11 +373,18 @@ async fn start_training(req: web::Json<StartTrainingRequest>, app_state: web::Da
         discharges: Vec::with_capacity(req.total_discharges),
     };
     *training_lock = Some(session);
-    HttpResponse::Ok().json(StartTrainingResponse { expected_discharges: req.total_discharges })
+    HttpResponse::Ok().json(StartTrainingResponse {
+        expected_discharges: req.total_discharges,
+    })
 }
 
 #[post("/train/{ordinal}")]
-async fn push_discharge(path: web::Path<usize>, req: web::Json<Discharge>, app_state: web::Data<AppState>) -> impl Responder {
+async fn push_discharge(
+    path: web::Path<usize>,
+    req: web::Json<Discharge>,
+    app_state: web::Data<AppState>,
+) -> impl Responder {
+    println!("Received discharge for training: {:?}", req.id);
     let ordinal = path.into_inner();
     let mut training_lock = app_state.training.write().unwrap();
     if let Some(session) = training_lock.as_mut() {
@@ -342,17 +396,30 @@ async fn push_discharge(path: web::Path<usize>, req: web::Json<Discharge>, app_s
         if ordinal == total {
             let discharges = training_lock.take().unwrap().discharges;
             drop(training_lock);
-            let (_response, model) = process_training_request(&discharges);
+            let (response, model) = process_training_request(&discharges);
             {
                 let mut model_lock = app_state.model.write().unwrap();
                 *model_lock = Some(model);
             }
             let _ = app_state.save_model_json(MODEL_PATH);
             *app_state.last_training.write().unwrap() = Some(Utc::now());
-            // TODO: send webhook with `response`
-            return HttpResponse::Ok().json(DischargeAck { ordinal, total_discharges: total });
+
+            // Send webhook with training response
+            let app_state_clone = app_state.clone();
+            let response_clone = response.clone();
+            tokio::spawn(async move {
+                app_state_clone.send_training_webhook(&response_clone).await;
+            });
+
+            return HttpResponse::Ok().json(DischargeAck {
+                ordinal,
+                total_discharges: total,
+            });
         }
-        return HttpResponse::Ok().json(DischargeAck { ordinal, total_discharges: total });
+        return HttpResponse::Ok().json(DischargeAck {
+            ordinal,
+            total_discharges: total,
+        });
     }
     HttpResponse::ServiceUnavailable().finish()
 }
@@ -400,6 +467,7 @@ async fn main() -> std::io::Result<()> {
         model: RwLock::new(None),
         training: RwLock::new(None),
         last_training: RwLock::new(None),
+        http_client: reqwest::Client::new(),
     });
 
     // Try to load model
@@ -410,19 +478,19 @@ async fn main() -> std::io::Result<()> {
     }
 
     let json_config = web::JsonConfig::default()
-        .limit(1 << 26)  // Tamaño max de 2^26 bytes (64 MB)
+        .limit(1 << 26) // Tamaño max de 2^26 bytes (64 MB)
         .error_handler(|err, _req| {
             log::error!("JSON payload error: {}", err);
             actix_web::error::InternalError::from_response(
-                err, 
+                err,
                 HttpResponse::BadRequest()
-                    .json(serde_json::json!({"error": "Payload too large or malformed"}))
-            ).into()
+                    .json(serde_json::json!({"error": "Payload too large or malformed"})),
+            )
+            .into()
         });
 
     log::info!("Starting SVM model server on http://0.0.0.0:8001");
     log::info!("Health check server on http://0.0.0.0:3001");
-
 
     // Start the health check server in a separate thread
     let health_data = app_state.clone();
@@ -448,7 +516,7 @@ async fn main() -> std::io::Result<()> {
     HttpServer::new(move || {
         App::new()
             .app_data(app_state.clone())
-            .app_data(json_config.clone())  // Aplicar configuración de tamaño JSON
+            .app_data(json_config.clone()) // Aplicar configuración de tamaño JSON
             .service(predict)
             .service(start_training)
             .service(push_discharge)


### PR DESCRIPTION
## Summary
- add new outlier protocol endpoints for training and prediction
- track training sessions and last training timestamp
- adjust health endpoint to match new protocol
- document new API in README

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6855ababdf848328befc2ced301f428d