### PR TITLE
Persist normalization params

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ mod signals;
 use actix_web::{App, HttpResponse, HttpServer, Responder, get, post, web};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use signals::get_dataset;
+use signals::{get_dataset, NormalizationParams};
 use std::sync::RwLock;
 use std::time::Instant;
 use uuid::Uuid;
@@ -22,16 +22,22 @@ const MODEL_PATH: &str = "trained_svm_model.json";
 
 struct AppState {
     model: RwLock<Option<Svm<f64, bool>>>,
+    norm_params: RwLock<Option<NormalizationParams>>, 
 }
 
 impl AppState {
     fn save_model_json(&self, path: &str) -> anyhow::Result<()> {
-        let model = self.model.read().unwrap();
-        if let Some(model) = &*model {
-            let json = serde_json::to_string(model)?;
+        let model_guard = self.model.read().unwrap();
+        let params_guard = self.norm_params.read().unwrap();
+        if let (Some(model), Some(params)) = (&*model_guard, &*params_guard) {
+            let state = serde_json::json!({
+                "model": model,
+                "params": params
+            });
+            let json = serde_json::to_string(&state)?;
             std::fs::write(path, json).map_err(|e| anyhow::anyhow!("Failed to save model: {}", e))?;
         } else {
-            return Err(anyhow::anyhow!("No model to save"));
+            return Err(anyhow::anyhow!("No model or params to save"));
         }
 
         log::info!("Model saved successfully to {}", path);
@@ -41,11 +47,14 @@ impl AppState {
 
     fn load_model_json(&self, path: &str) -> anyhow::Result<()> {
         let model_data = std::fs::read_to_string(path)?;
-        let model: Svm<f64, bool> = serde_json::from_str(&model_data)?;
+        let v: serde_json::Value = serde_json::from_str(&model_data)?;
+        let model: Svm<f64, bool> = serde_json::from_value(v["model"].clone())?;
+        let params: NormalizationParams = serde_json::from_value(v["params"].clone())?;
         *self.model.write().unwrap() = Some(model);
+        *self.norm_params.write().unwrap() = Some(params);
         log::info!("Model loaded successfully from {}", path);
         Ok(())
-    }    
+    }
 }
 
 // Data structures based on API schema
@@ -211,6 +220,7 @@ fn api_discharge_to_internal_signals(discharge: &Discharge) -> Vec<InternalSigna
 fn process_prediction_request(
     request: &PredictionRequest,
     model: &Option<Svm<f64, bool>>,
+    params: &Option<NormalizationParams>,
 ) -> PredictionResponse {
     let start_time = Instant::now();
     
@@ -232,7 +242,17 @@ fn process_prediction_request(
         )
     }).collect::<Vec<_>>();
     
-    let dataset = get_dataset(discharges);
+    if params.is_none() {
+        return PredictionResponse {
+            prediction: -1,
+            confidence: 0.0,
+            execution_time_ms: 0.0,
+            model: "none".to_string(),
+            details: serde_json::json!({ "error": "No normalization parameters" }),
+        };
+    }
+
+    let dataset = get_dataset(discharges, params.as_ref().unwrap());
     
     // Realizar predicción con el modelo
     let predictions = model.as_ref().unwrap()
@@ -257,7 +277,7 @@ fn process_prediction_request(
 }
 
 /// Procesa una petición de entrenamiento
-fn process_training_request(request: &TrainingRequest) -> (TrainingResponse, Svm<f64, bool>) {
+fn process_training_request(request: &TrainingRequest) -> (TrainingResponse, Svm<f64, bool>, NormalizationParams) {
     // Convertir todas las descargas y señales al formato interno
     let start_time = Instant::now();
 
@@ -280,7 +300,10 @@ fn process_training_request(request: &TrainingRequest) -> (TrainingResponse, Svm
         all_signals.extend(discharge.signals.clone());
     }
 
-    let dataset = get_dataset(discharges);
+    // Compute normalization parameters using all signals
+    let (_, params) = InternalSignal::normalize_vec(all_signals, None);
+
+    let dataset = get_dataset(discharges, &params);
 
     let model: Svm<f64, bool> = Svm::<f64, bool>::params()
         .gaussian_kernel(10.)
@@ -309,7 +332,7 @@ fn process_training_request(request: &TrainingRequest) -> (TrainingResponse, Svm
         execution_time_ms,
     };
 
-    (response, model)
+    (response, model, params)
 }
 
 // API endpoints
@@ -320,19 +343,24 @@ async fn predict(
     app_state: web::Data<AppState>,
 ) -> impl Responder {
     let model = app_state.model.read().unwrap();
-    let response = process_prediction_request(&req, &model);
+    let params = app_state.norm_params.read().unwrap();
+    let response = process_prediction_request(&req, &model, &params);
     HttpResponse::Ok().json(response)
 }
 
 #[post("/train")]
 async fn train(req: web::Json<TrainingRequest>, app_state: web::Data<AppState>) -> impl Responder {
     println!("Received training petition");
-    let (response, model) = process_training_request(&req);
+    let (response, model, params) = process_training_request(&req);
 
     {
         let mut model_lock: std::sync::RwLockWriteGuard<'_, Option<Svm<f64, bool>>> = app_state.model.write().unwrap();
         *model_lock = Some(model);
-    } // When model_lock goes out of scope, the lock is released
+    }
+    {
+        let mut params_lock = app_state.norm_params.write().unwrap();
+        *params_lock = Some(params);
+    }
 
     // Save the trained model to a file
     let model_path = MODEL_PATH;
@@ -388,6 +416,7 @@ async fn main() -> std::io::Result<()> {
 
     let app_state = web::Data::new(AppState {
         model: RwLock::new(None),
+        norm_params: RwLock::new(None),
     });
 
     // Try to load model

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ mod signals;
 use actix_web::{App, HttpResponse, HttpServer, Responder, get, post, web};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use signals::{get_dataset, NormalizationParams};
+use signals::{NormalizationParams, get_dataset};
 use std::sync::RwLock;
 use std::time::Instant;
 use uuid::Uuid;
@@ -22,7 +22,13 @@ const MODEL_PATH: &str = "trained_svm_model.json";
 
 struct AppState {
     model: RwLock<Option<Svm<f64, bool>>>,
-    norm_params: RwLock<Option<NormalizationParams>>, 
+    norm_params: RwLock<Option<NormalizationParams>>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct SavedState {
+    model: Svm<f64, bool>,
+    params: NormalizationParams,
 }
 
 impl AppState {
@@ -30,12 +36,13 @@ impl AppState {
         let model_guard = self.model.read().unwrap();
         let params_guard = self.norm_params.read().unwrap();
         if let (Some(model), Some(params)) = (&*model_guard, &*params_guard) {
-            let state = serde_json::json!({
-                "model": model,
-                "params": params
-            });
+            let state = SavedState {
+                model: model.clone(),
+                params: params.clone(),
+            };
             let json = serde_json::to_string(&state)?;
-            std::fs::write(path, json).map_err(|e| anyhow::anyhow!("Failed to save model: {}", e))?;
+            std::fs::write(path, json)
+                .map_err(|e| anyhow::anyhow!("Failed to save model: {}", e))?;
         } else {
             return Err(anyhow::anyhow!("No model or params to save"));
         }
@@ -47,11 +54,9 @@ impl AppState {
 
     fn load_model_json(&self, path: &str) -> anyhow::Result<()> {
         let model_data = std::fs::read_to_string(path)?;
-        let v: serde_json::Value = serde_json::from_str(&model_data)?;
-        let model: Svm<f64, bool> = serde_json::from_value(v["model"].clone())?;
-        let params: NormalizationParams = serde_json::from_value(v["params"].clone())?;
-        *self.model.write().unwrap() = Some(model);
-        *self.norm_params.write().unwrap() = Some(params);
+        let state: SavedState = serde_json::from_str(&model_data)?;
+        *self.model.write().unwrap() = Some(state.model);
+        *self.norm_params.write().unwrap() = Some(state.params);
         log::info!("Model loaded successfully from {}", path);
         Ok(())
     }
@@ -223,7 +228,7 @@ fn process_prediction_request(
     params: &Option<NormalizationParams>,
 ) -> PredictionResponse {
     let start_time = Instant::now();
-    
+
     // Si no hay modelo entrenado, devolver respuesta por defecto
     if model.is_none() {
         return PredictionResponse {
@@ -235,13 +240,17 @@ fn process_prediction_request(
         };
     }
 
-    let discharges = request.discharges.iter().map(|d| {
-        InternalDischarge::new(
-            DisruptionClass::Unknown, // La clase es desconocida en predicción
-            api_discharge_to_internal_signals(d),
-        )
-    }).collect::<Vec<_>>();
-    
+    let discharges = request
+        .discharges
+        .iter()
+        .map(|d| {
+            InternalDischarge::new(
+                DisruptionClass::Unknown, // La clase es desconocida en predicción
+                api_discharge_to_internal_signals(d),
+            )
+        })
+        .collect::<Vec<_>>();
+
     if params.is_none() {
         return PredictionResponse {
             prediction: -1,
@@ -253,18 +262,21 @@ fn process_prediction_request(
     }
 
     let dataset = get_dataset(discharges, params.as_ref().unwrap());
-    
+
     // Realizar predicción con el modelo
-    let predictions = model.as_ref().unwrap()
-        .predict(&dataset);
-    
+    let predictions = model.as_ref().unwrap().predict(&dataset);
+
     // Determinar si hay anomalía (true representa anomalía)
     let anomaly_count = predictions.iter().filter(|&&p| p).count();
     let total = predictions.len();
-    let confidence = if total > 0 { anomaly_count as f64 / total as f64 } else { 0.0 };
-    
+    let confidence = if total > 0 {
+        anomaly_count as f64 / total as f64
+    } else {
+        0.0
+    };
+
     let prediction = if confidence > 0.5 { 1 } else { 0 };
-    
+
     PredictionResponse {
         prediction,
         confidence,
@@ -277,7 +289,9 @@ fn process_prediction_request(
 }
 
 /// Procesa una petición de entrenamiento
-fn process_training_request(request: &TrainingRequest) -> (TrainingResponse, Svm<f64, bool>, NormalizationParams) {
+fn process_training_request(
+    request: &TrainingRequest,
+) -> (TrainingResponse, Svm<f64, bool>, NormalizationParams) {
     // Convertir todas las descargas y señales al formato interno
     let start_time = Instant::now();
 
@@ -354,7 +368,8 @@ async fn train(req: web::Json<TrainingRequest>, app_state: web::Data<AppState>) 
     let (response, model, params) = process_training_request(&req);
 
     {
-        let mut model_lock: std::sync::RwLockWriteGuard<'_, Option<Svm<f64, bool>>> = app_state.model.write().unwrap();
+        let mut model_lock: std::sync::RwLockWriteGuard<'_, Option<Svm<f64, bool>>> =
+            app_state.model.write().unwrap();
         *model_lock = Some(model);
     }
     {
@@ -365,7 +380,7 @@ async fn train(req: web::Json<TrainingRequest>, app_state: web::Data<AppState>) 
     // Save the trained model to a file
     let model_path = MODEL_PATH;
     let res = app_state.save_model_json(model_path);
-    
+
     if res.is_err() {
         log::warn!("Unable to save model")
     }
@@ -427,34 +442,32 @@ async fn main() -> std::io::Result<()> {
     }
 
     let json_config = web::JsonConfig::default()
-        .limit(1 << 26)  // Tamaño max de 2^26 bytes (64 MB)
+        .limit(1 << 26) // Tamaño max de 2^26 bytes (64 MB)
         .error_handler(|err, _req| {
             log::error!("JSON payload error: {}", err);
             actix_web::error::InternalError::from_response(
-                err, 
+                err,
                 HttpResponse::BadRequest()
-                    .json(serde_json::json!({"error": "Payload too large or malformed"}))
-            ).into()
+                    .json(serde_json::json!({"error": "Payload too large or malformed"})),
+            )
+            .into()
         });
 
     log::info!("Starting SVM model server on http://0.0.0.0:8001");
     log::info!("Health check server on http://0.0.0.0:3001");
-
 
     // Start the health check server in a separate thread
     std::thread::spawn(|| {
         // Use the system runtime for the health check server
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
-            HttpServer::new(|| {
-                App::new().service(health_check)
-            })
-            .workers(1) // Use only one worker for health checks
-            .bind(("0.0.0.0", 3001))
-            .unwrap()
-            .run()
-            .await
-            .unwrap();
+            HttpServer::new(|| App::new().service(health_check))
+                .workers(1) // Use only one worker for health checks
+                .bind(("0.0.0.0", 3001))
+                .unwrap()
+                .run()
+                .await
+                .unwrap();
         });
     });
 
@@ -462,7 +475,7 @@ async fn main() -> std::io::Result<()> {
     HttpServer::new(move || {
         App::new()
             .app_data(app_state.clone())
-            .app_data(json_config.clone())  // Aplicar configuración de tamaño JSON
+            .app_data(json_config.clone()) // Aplicar configuración de tamaño JSON
             .service(predict)
             .service(train)
     })

--- a/src/signals/mod.rs
+++ b/src/signals/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, hash::Hash};
 use linfa::Dataset;
 use ndarray::{Array1, Array2, Ix1};
 use rustfft::{FftPlanner, num_complex::Complex};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 const WINDOW_SIZE: usize = 16;
 
@@ -30,7 +30,7 @@ pub enum DisruptionClass {
     Unknown,
 }
 
-#[derive(Debug, Clone, Deserialize, Eq, Hash, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, Hash, PartialEq)]
 pub enum SignalType {
     CorrientePlasma,
     ModeLock,
@@ -45,6 +45,12 @@ impl SignalType {
     pub fn count() -> usize {
         7
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct NormalizationParams {
+    pub min: HashMap<SignalType, f64>,
+    pub max: HashMap<SignalType, f64>,
 }
 
 #[derive(Debug)]
@@ -119,22 +125,30 @@ impl Signal {
     /// \[ x_{norm} = \frac{x - x_{min}}{x_{max} - x_{min}} \]
     /// donde \( x_{min} \) y \( x_{max} \) son los valores mínimo y máximo de todas las señales del mismo tipo.
     /// Devuelve un vector con las señales normalizadas.
-    pub fn normalize_vec(signals: Vec<Signal>) -> Vec<Signal> {
+    pub fn normalize_vec(
+        signals: Vec<Signal>,
+        params: Option<&NormalizationParams>,
+    ) -> (Vec<Signal>, NormalizationParams) {
         let mut signals_norm = Vec::new();
 
         let mut min_by_type: HashMap<SignalType, f64> = HashMap::new();
         let mut max_by_type: HashMap<SignalType, f64> = HashMap::new();
 
-        for signal in &signals {
-            let min_entry = min_by_type
-                .entry(signal.signal_type.clone())
-                .or_insert(f64::MAX);
-            *min_entry = min_entry.min(signal.min);
+        if let Some(p) = params {
+            min_by_type = p.min.clone();
+            max_by_type = p.max.clone();
+        } else {
+            for signal in &signals {
+                let min_entry = min_by_type
+                    .entry(signal.signal_type.clone())
+                    .or_insert(f64::MAX);
+                *min_entry = min_entry.min(signal.min);
 
-            let max_entry = max_by_type
-                .entry(signal.signal_type.clone())
-                .or_insert(f64::MIN);
-            *max_entry = max_entry.max(signal.max);
+                let max_entry = max_by_type
+                    .entry(signal.signal_type.clone())
+                    .or_insert(f64::MIN);
+                *max_entry = max_entry.max(signal.max);
+            }
         }
 
         for signal in signals {
@@ -161,7 +175,13 @@ impl Signal {
             });
         }
 
-        signals_norm
+        (
+            signals_norm,
+            NormalizationParams {
+                min: min_by_type,
+                max: max_by_type,
+            },
+        )
     }
 
     /// Calcula las características de la señal en ventanas de tamaño `window_size`.
@@ -240,7 +260,10 @@ impl Discharge {
     }
 }
 
-pub fn get_dataset(discharges: Vec<Discharge>) -> Dataset<f64, bool, Ix1> {
+pub fn get_dataset(
+    discharges: Vec<Discharge>,
+    params: &NormalizationParams,
+) -> Dataset<f64, bool, Ix1> {
     // Process each discharge separately and combine the results
     let mut all_records = Vec::new();
     let mut all_targets = Vec::new();
@@ -248,7 +271,7 @@ pub fn get_dataset(discharges: Vec<Discharge>) -> Dataset<f64, bool, Ix1> {
     for discharge in &discharges {
         // Normalize signals for this discharge
         let discharge_signals = discharge.signals.clone();
-        let normalized_signals = Signal::normalize_vec(discharge_signals);
+        let normalized_signals = Signal::normalize_vec(discharge_signals, Some(params)).0;
 
         // Process signals by type for this discharge
         let mut features_by_type: HashMap<SignalType, (Vec<f64>, Vec<f64>)> = HashMap::new();


### PR DESCRIPTION
## Summary
- add `NormalizationParams` struct to store min/max by signal type
- allow pre-computed normalization in `Signal::normalize_vec` and `get_dataset`
- persist normalization data with the SVM model in `AppState`
- normalize using stored parameters during prediction and training

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686ab7119b508328ab4fbcafaabdf1af