### PR TITLE
Add normalization parameter handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use actix_web::{App, HttpResponse, HttpServer, Responder, get, post, web};
 use chrono::{DateTime, Utc};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
-use signals::get_dataset;
+use signals::{get_dataset, compute_normalization_params, NormalizationParams};
 use std::sync::RwLock;
 use std::time::Instant;
 use uuid::Uuid;
@@ -28,18 +28,26 @@ struct AppState {
     model: RwLock<Option<Svm<f64, bool>>>,
     training: RwLock<Option<TrainingSession>>,
     last_training: RwLock<Option<DateTime<Utc>>>,
+    normalization_params: RwLock<Option<NormalizationParams>>,
     http_client: reqwest::Client,
 }
 
 impl AppState {
     fn save_model_json(&self, path: &str) -> anyhow::Result<()> {
         let model = self.model.read().unwrap();
-        if let Some(model) = &*model {
-            let json = serde_json::to_string(model)?;
+        let params = self.normalization_params.read().unwrap();
+        if let (Some(model), Some(params)) = (&*model, &*params) {
+            #[derive(Serialize)]
+            struct ModelFile<'a> {
+                model: &'a Svm<f64, bool>,
+                params: &'a NormalizationParams,
+            }
+            let data = ModelFile { model, params };
+            let json = serde_json::to_string(&data)?;
             std::fs::write(path, json)
                 .map_err(|e| anyhow::anyhow!("Failed to save model: {}", e))?;
         } else {
-            return Err(anyhow::anyhow!("No model to save"));
+            return Err(anyhow::anyhow!("No model or params to save"));
         }
 
         log::info!("Model saved successfully to {}", path);
@@ -48,9 +56,16 @@ impl AppState {
     }
 
     fn load_model_json(&self, path: &str) -> anyhow::Result<()> {
+        #[derive(Deserialize)]
+        struct ModelFile {
+            model: Svm<f64, bool>,
+            params: NormalizationParams,
+        }
+
         let model_data = std::fs::read_to_string(path)?;
-        let model: Svm<f64, bool> = serde_json::from_str(&model_data)?;
-        *self.model.write().unwrap() = Some(model);
+        let model_file: ModelFile = serde_json::from_str(&model_data)?;
+        *self.model.write().unwrap() = Some(model_file.model);
+        *self.normalization_params.write().unwrap() = Some(model_file.params);
         log::info!("Model loaded successfully from {}", path);
         Ok(())
     }
@@ -248,6 +263,7 @@ fn api_discharge_to_internal_signals(discharge: &Discharge) -> Vec<InternalSigna
 fn process_prediction_request(
     discharge: &Discharge,
     model: &Option<Svm<f64, bool>>,
+    params: Option<&NormalizationParams>,
 ) -> PredictionResponse {
     let start_time = Instant::now();
     let mut window_props: Vec<WindowProperties> = Vec::new();
@@ -258,7 +274,7 @@ fn process_prediction_request(
     );
     
     // If no model is loaded, return unknown prediction
-    if model.is_none() {
+    if model.is_none() || params.is_none() {
         log::warn!("No model loaded, returning unknown prediction");
         return PredictionResponse {
             prediction: "Unknown".to_string(),
@@ -275,7 +291,7 @@ fn process_prediction_request(
         api_discharge_to_internal_signals(discharge),
     )];
 
-    let dataset = get_dataset(discharges);
+    let dataset = get_dataset(discharges, params.unwrap());
 
     // Realizar predicción con el modelo
     let predictions = model.as_ref().unwrap().predict(&dataset);
@@ -315,7 +331,9 @@ fn process_prediction_request(
 }
 
 /// Procesa una petición de entrenamiento
-fn process_training_request(discharges: &[Discharge]) -> (TrainingResponse, Svm<f64, bool>) {
+fn process_training_request(
+    discharges: &[Discharge],
+) -> (TrainingResponse, Svm<f64, bool>, NormalizationParams) {
     // Convertir todas las descargas y señales al formato interno
     let start_time = Instant::now();
 
@@ -332,12 +350,9 @@ fn process_training_request(discharges: &[Discharge]) -> (TrainingResponse, Svm<
         })
         .collect::<Vec<_>>();
 
-    let mut all_signals = Vec::new();
-    for discharge in &discharges {
-        all_signals.extend(discharge.signals.clone());
-    }
+    let params = compute_normalization_params(&discharges);
 
-    let dataset = get_dataset(discharges);
+    let dataset = get_dataset(discharges, &params);
 
     let model: Svm<f64, bool> = Svm::<f64, bool>::params()
         .gaussian_kernel(10.)
@@ -366,7 +381,7 @@ fn process_training_request(discharges: &[Discharge]) -> (TrainingResponse, Svm<
         execution_time_ms,
     };
 
-    (response, model)
+    (response, model, params)
 }
 
 // API endpoints
@@ -374,7 +389,8 @@ fn process_training_request(discharges: &[Discharge]) -> (TrainingResponse, Svm<
 #[post("/predict")]
 async fn predict(req: web::Json<Discharge>, app_state: web::Data<AppState>) -> impl Responder {
     let model = app_state.model.read().unwrap();
-    let response = process_prediction_request(&req, &model);
+    let params_guard = app_state.normalization_params.read().unwrap();
+    let response = process_prediction_request(&req, &model, params_guard.as_ref());
     HttpResponse::Ok().json(response)
 }
 
@@ -420,10 +436,14 @@ async fn push_discharge(
         if ordinal == total {
             let discharges = training_lock.take().unwrap().discharges;
             drop(training_lock);
-            let (response, model) = process_training_request(&discharges);
+            let (response, model, params) = process_training_request(&discharges);
             {
                 let mut model_lock = app_state.model.write().unwrap();
                 *model_lock = Some(model);
+            }
+            {
+                let mut params_lock = app_state.normalization_params.write().unwrap();
+                *params_lock = Some(params);
             }
             let _ = app_state.save_model_json(MODEL_PATH);
             *app_state.last_training.write().unwrap() = Some(Utc::now());
@@ -491,6 +511,7 @@ async fn main() -> std::io::Result<()> {
         model: RwLock::new(None),
         training: RwLock::new(None),
         last_training: RwLock::new(None),
+        normalization_params: RwLock::new(None),
         http_client: reqwest::Client::new(),
     });
 

--- a/src/signals/mod.rs
+++ b/src/signals/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, hash::Hash};
 use linfa::Dataset;
 use ndarray::{Array1, Array2, Ix1};
 use rustfft::{num_complex::Complex, FftPlanner};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 pub const WINDOW_SIZE: usize = 16;
 
@@ -30,7 +30,7 @@ pub enum DisruptionClass {
     Unknown,
 }
 
-#[derive(Debug, Clone, Deserialize, Eq, Hash, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, Hash, PartialEq)]
 pub enum SignalType {
     CorrientePlasma,
     ModeLock,
@@ -45,6 +45,11 @@ impl SignalType {
     pub fn count() -> usize {
         7
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct NormalizationParams {
+    pub by_type: HashMap<SignalType, (f64, f64)>,
 }
 
 #[derive(Debug)]
@@ -164,6 +169,41 @@ impl Signal {
         signals_norm
     }
 
+    pub fn normalize_vec_with_params(
+        signals: Vec<Signal>,
+        params: &NormalizationParams,
+    ) -> Vec<Signal> {
+        let mut signals_norm = Vec::new();
+
+        for signal in signals {
+            if let Some((global_min, global_max)) = params.by_type.get(&signal.signal_type) {
+                let mut values_norm = Vec::with_capacity(signal.values.len());
+                for value in signal.values {
+                    let value_norm = (value - global_min) / (global_max - global_min);
+                    values_norm.push(value_norm);
+                }
+
+                let local_min = values_norm.iter().fold(f64::MAX, |a, b| a.min(*b));
+                let local_max = values_norm.iter().fold(f64::MIN, |a, b| a.max(*b));
+
+                signals_norm.push(Signal {
+                    label: signal.label,
+                    _times: signal._times,
+                    values: values_norm,
+                    class: signal.class,
+                    signal_type: signal.signal_type,
+                    min: local_min,
+                    max: local_max,
+                });
+            } else {
+                // If no parameters found, push signal without modification
+                signals_norm.push(signal);
+            }
+        }
+
+        signals_norm
+    }
+
     /// Calcula las características de la señal en ventanas de tamaño `window_size`.
     /// Devuelve dos vectores con los valores medios y desviaciones estándar de la FFT.
     /// **Se asume que la señal ya está normalizada.**
@@ -240,7 +280,26 @@ impl Discharge {
     }
 }
 
-pub fn get_dataset(discharges: Vec<Discharge>) -> Dataset<f64, bool, Ix1> {
+pub fn compute_normalization_params(discharges: &[Discharge]) -> NormalizationParams {
+    let mut map: HashMap<SignalType, (f64, f64)> = HashMap::new();
+
+    for discharge in discharges {
+        for signal in &discharge.signals {
+            let entry = map
+                .entry(signal.signal_type.clone())
+                .or_insert((f64::MAX, f64::MIN));
+            entry.0 = entry.0.min(signal.min);
+            entry.1 = entry.1.max(signal.max);
+        }
+    }
+
+    NormalizationParams { by_type: map }
+}
+
+pub fn get_dataset(
+    discharges: Vec<Discharge>,
+    params: &NormalizationParams,
+) -> Dataset<f64, bool, Ix1> {
     // Process each discharge separately and combine the results
     let mut all_records = Vec::new();
     let mut all_targets = Vec::new();
@@ -248,7 +307,7 @@ pub fn get_dataset(discharges: Vec<Discharge>) -> Dataset<f64, bool, Ix1> {
     for discharge in &discharges {
         // Normalize signals for this discharge
         let discharge_signals = discharge.signals.clone();
-        let normalized_signals = Signal::normalize_vec(discharge_signals);
+        let normalized_signals = Signal::normalize_vec_with_params(discharge_signals, params);
 
         // Process signals by type for this discharge
         let mut features_by_type: HashMap<SignalType, (Vec<f64>, Vec<f64>)> = HashMap::new();


### PR DESCRIPTION
## Summary
- add `NormalizationParams` for global min/max per signal type
- compute normalization parameters during training
- persist model with parameters
- normalize signals using saved parameters for both training and prediction

## Testing
- `cargo check`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686ac993267083288f1414f9fa6f1c35